### PR TITLE
Add GoSec Security Scans

### DIFF
--- a/.github/workflows/gosec.yml
+++ b/.github/workflows/gosec.yml
@@ -1,0 +1,32 @@
+name: Run Gosec
+on:
+  workflow_dispatch:
+  schedule:
+    #        ┌───────────── minute (0 - 59)
+    #        │  ┌───────────── hour (0 - 23)
+    #        │  │ ┌───────────── day of the month (1 - 31)
+    #        │  │ │ ┌───────────── month (1 - 12 or JAN-DEC)
+    #        │  │ │ │ ┌───────────── day of the week (0 - 6 or SUN-SAT)
+    #        │  │ │ │ │
+    #        │  │ │ │ │
+    #        │  │ │ │ │
+    #        *  * * * *
+    - cron: '30 1 * * *'
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    env:
+      GO111MODULE: on
+    steps:
+      - name: Checkout Source
+        uses: actions/checkout@v2
+
+      - name: Run Gosec Security Scanner
+        uses: securego/gosec@master
+        with:
+          args: './...'
+
+      - name: Upload SARIF file
+        uses: github/codeql-action/upload-sarif@v1
+        with:
+          sarif_file: results.sarif


### PR DESCRIPTION
## Motivation
Follow up to issue open-telemetry/oteps# 144

[GoSec](https://github.com/securego/gosec) is a static analysis engine which scans go source code for security vulnerabilities. As the project grows and we near GA it might be useful to have a workflow which checks for security vulnerabilities so we can ensure every incremental change is following best development practices. Also passing basic security checks will also make sure that there aren't any glaring issues for our users.

## Changes
This PR adds GoSec security checks to the repo
* After every run the workflow uploads the results to GitHub. Details on the run and security alerts will show up in the security tab of this repo.

**Workflow Triggers**

* daily cron job at 1:30am
* workflow_dispatch (in case maintainers want to trigger a security check manually)

cc @alolita